### PR TITLE
Replace deprecated rich_compare kwarg

### DIFF
--- a/blockcanvas/app/experiment.py
+++ b/blockcanvas/app/experiment.py
@@ -5,7 +5,8 @@ import os
 from os.path import join
 
 # Enthought library imports
-from traits.api import HasTraits, Instance, on_trait_change, Property, String
+from traits.api import (HasTraits, Instance, on_trait_change, Property, String,
+    OBJECT_IDENTITY_COMPARE)
 
 # CodeTools imports
 from codetools.execution.executing_context import ExecutingContext
@@ -63,12 +64,13 @@ class Experiment(HasTraits):
 
     # A shadow trait for **shared_context** property
     _shared_context = Instance(IListenableContext, adapt='yes',
-        rich_compare=False)
+        comparison_mode=OBJECT_IDENTITY_COMPARE)
 
     # The context in which all of our execution model's generated values are
     # stored.  This context is exposed as part of self.context.  This remains
     # constant even as the _shared_context gets changed.
-    _local_context = Instance(IListenableContext, rich_compare=False)
+    _local_context = Instance(IListenableContext,
+        comparison_mode=OBJECT_IDENTITY_COMPARE)
 
     # Class-level generator for the name of the local context; takes
     # **self** as an argument.

--- a/blockcanvas/app/project.py
+++ b/blockcanvas/app/project.py
@@ -8,7 +8,7 @@ from os.path import abspath, join
 
 # Enthought library imports
 from traits.api import (Directory, HasTraits, Instance, Int, List,
-        on_trait_change, Property, Trait)
+        on_trait_change, Property, Trait, OBJECT_IDENTITY_COMPARE)
 
 # Block canvas imports
 from codetools.contexts.api import IListenableContext
@@ -27,7 +27,8 @@ class Project(HasTraits):
     """
 
     # A list of contexts that are associated with the project
-    contexts = List(Instance(IListenableContext, adapt='yes', rich_compare=False))
+    contexts = List(Instance(IListenableContext, adapt='yes',
+        comparison_mode=OBJECT_IDENTITY_COMPARE))
 
     # A list of the experiments in this project
     experiments = List(Instance(Experiment))

--- a/blockcanvas/context/ui/context_variable.py
+++ b/blockcanvas/context/ui/context_variable.py
@@ -5,7 +5,8 @@ import numpy
 
 from pyface.timer.api import do_later
 from traits.api import (Any, Bool, Event, HasTraits, Instance, List,
-    Property, Str, TraitError, Undefined, on_trait_change)
+    Property, Str, TraitError, Undefined, on_trait_change,
+    OBJECT_IDENTITY_COMPARE)
 import traitsui.api as tui
 from traits.protocols.api import AdaptationFailure, adapt
 from traitsui.menu import OKCancelButtons
@@ -184,7 +185,7 @@ class ContextVariableList(HasTraits):
 
     # The context to be viewed.
     context = Instance(IListenableContext, factory=DataContext, adapt='yes',
-        rich_compare=False)
+        comparison_mode=OBJECT_IDENTITY_COMPARE)
 
     # One ContextVariable for each name in the context.
     variables = List(Any())


### PR DESCRIPTION
`rich_compare` has been deprecated since version 3.0.3 of traits and it's been replaced with the `comparison_mode` kwarg.

See PR https://github.com/enthought/traits/pull/598/ for more information.