### PR TITLE
Replace trait types false and true with Bool(False) and Bool(True)

### DIFF
--- a/blockcanvas/canvas/block_canvas.py
+++ b/blockcanvas/canvas/block_canvas.py
@@ -5,7 +5,7 @@ import pickle
 import warnings
 
 # Enthought library imports
-from traits.api import Any, Bool, false, Float, Instance
+from traits.api import Any, Bool, Float, Instance
 from enable.api import Canvas
 
 # Local imports
@@ -28,7 +28,7 @@ class BlockCanvas(Canvas):
 
     # Override from DragTool base class.  Do not end drag operation
     # upon leaving the component.
-    end_drag_on_leave = false
+    end_drag_on_leave = Bool(False)
 
     #---------------------------------------------------------------------
     # Component traits
@@ -92,7 +92,7 @@ class BlockCanvas(Canvas):
 
         ## On the initial layout, the boxes haven't been created yet.
         self.graph_controller.update_nodes([self.graph_controller.execution_model.dep_graph.keys()],[],[])
-        
+
     def save_layout(self, filename):
         """ Save the layout of the canvas to the given filename.
         """
@@ -103,7 +103,7 @@ class BlockCanvas(Canvas):
         file = open(filename, 'w')
         pickle.dump(id_position_map, file)
         file.close()
-        
+
     #---------------------------------------------------------------------
     # Container interface.
     #---------------------------------------------------------------------

--- a/blockcanvas/model/numeric_model.py
+++ b/blockcanvas/model/numeric_model.py
@@ -17,7 +17,7 @@ from enable.trait_defs.api import RGBAColor
 from traits.api \
     import HasTraits, HasPrivateTraits, Event, List, Str, Instance, Property, \
            Delegate, Expression, Constant, Callable, Enum, Bool, Int, Array, \
-           Any, Float, true, false
+           Any, Float
 
 from traitsui.api \
     import View
@@ -560,7 +560,7 @@ class ANumericItem ( HasPrivateTraits ):
     slicer = Callable
 
     # Does the value have an associated quantity?
-    is_quantity = false
+    is_quantity = Bool(False)
 
 #-- View related ---------------------------------------------------------------
 
@@ -1170,7 +1170,7 @@ class ReductionModel ( FilterModel ):
 
     # Should filtered out values be set to a specified value, rather than
     # discarded?
-    use_value = false
+    use_value = Bool(False)
 
     #---------------------------------------------------------------------------
     #  Gets a ReductionModel associated with the model:
@@ -1474,4 +1474,3 @@ class PassThruModel ( TerminationModel ):
         """ The generic implementation of the item data property.
         """
         return getattr( self.model, name )
-

--- a/blockcanvas/model/quantity_model.py
+++ b/blockcanvas/model/quantity_model.py
@@ -19,7 +19,7 @@ from NumericModel \
     import NumericItem, NumericModelBase, NumericModel, DerivationModel
 
 from traits.api \
-    import Category
+    import Bool, Category
 
 from scimath.units \
     import unit_manager
@@ -41,7 +41,7 @@ class QuantityNumericItem ( Category, NumericItem ):
     #---------------------------------------------------------------------------
 
     # Is the referenced value an array or a Quantity (i.e. has units)?
-    is_quantity = false
+    is_quantity = Bool(False)
 
     # The current value of the associated numeric array (override):
     data = Property
@@ -182,4 +182,3 @@ class QuantityDerivationModel ( Category, DerivationModel ):
             item.
         """
         return self.model._get_quantity_for( name )
-

--- a/blockcanvas/model/traits/ui/wx/numeric_editor.py
+++ b/blockcanvas/model/traits/ui/wx/numeric_editor.py
@@ -27,7 +27,7 @@ from numpy \
 
 from traits.api \
     import HasPrivateTraits, List, Enum, Str, Instance, Int, Any, Callable, \
-           Color, Font, Bool, Expression, Property, true, false
+           Color, Font, Bool, Expression, Property
 
 from traitsui.api \
     import View, VGroup, Item, SetEditor, TableEditor, EnumEditor
@@ -1364,16 +1364,16 @@ class ToolkitEditorFactory ( BasicEditorFactory ):
     klass = NumericEditor
 
     # Should an external selection be automatically selected in the editor?
-    auto_select = true
+    auto_select = Bool(True)
 
     # Can the user add new columns to the model?
-    extendable = true
+    extendable = Bool(True)
 
     # Where should new columns be added
     new_columns = Enum( 'last', [ 'first', 'last' ] )
 
     # Can the user configure the table columns?
-    configurable = true
+    configurable = Bool(True)
 
     # List of initial table column descriptors
     columns = List( NumericColumn )
@@ -1382,13 +1382,13 @@ class ToolkitEditorFactory ( BasicEditorFactory ):
     other_columns = List( NumericColumn )
 
     # Can the user choose the selection filter?
-    choose_selection_filter = true
+    choose_selection_filter = Bool(True)
 
     # Can the user edit the selection filter?
-    edit_selection_filter = true
+    edit_selection_filter = Bool(True)
 
     # Can the user edit the selection colors?
-    edit_selection_colors = true
+    edit_selection_colors = Bool(True)
 
     # The filter to use for selecting model data. This trait is mutually
     # exclusive with **selection_filter_name**.
@@ -1403,10 +1403,10 @@ class ToolkitEditorFactory ( BasicEditorFactory ):
     user_selection_filter = Instance( IndexFilter )
 
     # Can the user choose the reduction filter?
-    choose_reduction_filter = true
+    choose_reduction_filter = Bool(True)
 
     # Can the user edit the reduction filter?
-    edit_reduction_filter = true
+    edit_reduction_filter = Bool(True)
 
     # The filter to use for reducing the model data. This trait is mutually
     # exclusive with **reduction_filter_name**.
@@ -1417,22 +1417,22 @@ class ToolkitEditorFactory ( BasicEditorFactory ):
     reduction_filter_name = Str
 
     # Are rows deletable from the table?
-    deletable = false
+    deletable = Bool(False)
 
     # Can the user sort the data?
-    sortable = false
+    sortable = Bool(False)
 
     # Does sorting affect the model?
-    sort_model = false
+    sort_model = Bool(False)
 
     # Is the table editable?
-    editable = true
+    editable = Bool(True)
 
     # Should the cells of the table automatically size to the optimal size?
-    auto_size = false
+    auto_size = Bool(False)
 
     # Should grid lines be shown on the table?
-    show_lines = true
+    show_lines = Bool(True)
 
     # Default context menu to display when any cell is right_clicked
     menu = Instance( Menu )
@@ -1441,7 +1441,7 @@ class ToolkitEditorFactory ( BasicEditorFactory ):
     line_color = Color( 0xC4C0A9 )
 
     # Should column labels be displayed?
-    show_column_labels = true
+    show_column_labels = Bool(True)
 
     # The default font to use for text in cells
     cell_font = Font
@@ -1481,4 +1481,3 @@ class ToolkitEditorFactory ( BasicEditorFactory ):
 
     # Called when a table item is double-clicked
     on_dclick = Callable
-

--- a/blockcanvas/numerical_modeling/units/traits/ui/unit_editor.py
+++ b/blockcanvas/numerical_modeling/units/traits/ui/unit_editor.py
@@ -9,7 +9,7 @@
 #-------------------------------------------------------------------------------
 
 from traits.api \
-    import CFloat, false, HasPrivateTraits, Instance, Str
+    import Bool, CFloat, HasPrivateTraits, Instance, Str
 
 from traitsui.api \
     import View, HGroup, Item, Label
@@ -89,7 +89,7 @@ class SimpleEditor ( UIEditor ):
     unit_view = Instance( UnitView )
 
     # should this editor be readonly?
-    readonly = false
+    readonly = Bool(False)
 
     #-- Trait Views ------------------------------------------------------------
 


### PR DESCRIPTION
The `TraitType` constants `false` and `true` will be deprecated in Traits 6.0.0. This PR replaces uses of those trait types with `Bool(False)` or `Bool(True)` as appropriate.

See enthought/traits#627